### PR TITLE
refactor: no default exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The examples below were tested using Webpack, if you use another module bundler 
 Import the whole library and use it on your app:
 
 ```javascript
-import commons from '@linx/commons-js';
+import { commons } from '@linx/commons-js';
 
 // make an ajax request
 commons.http.ajax({
@@ -29,7 +29,7 @@ commons.http.ajax({
 Import just the `Http` module. Only the implementation of this module functions will be bundled to your application source code.
 
 ```javascript
-import http from '@linx/commons-js/http';
+import { http } from '@linx/commons-js/http';
 
 // make an ajax request
 http.ajax({
@@ -43,7 +43,7 @@ http.ajax({
 Import just the `ajax` function. Only the implementation of this function will be bundled to your application source code.
 
 ```javascript
-import ajax from '@linx/commons-js/http/ajax';
+import { ajax } from '@linx/commons-js/http/ajax';
 
 // make an ajax request
 ajax({

--- a/src/http/ajax.js
+++ b/src/http/ajax.js
@@ -30,7 +30,7 @@
  * @param {function} options.error A function to execute when some error
  *          occurs on request.
  */
-export default function ajax(options) {
+export function ajax(options) {
   const callback = (typeof options.callback === 'function') ?
     options.callback :
     () => { };

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -11,11 +11,11 @@
  * of the license agreement you entered into with Linx S.A.
  */
 
-import ajax from './ajax';
+import { ajax } from './ajax';
 
 /**
  * Http module.
  *
  * @module @linx/commons-js/http
  */
-export default { ajax };
+export { ajax };

--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,7 @@ import http from './http';
 /**
  * @module @linx/commons-js
  */
-const commons = { http };
+export const commons = { http };
 
 window.top.linx = window.top.linx || {};
 window.top.linx.commons = commons;
-
-export default commons;

--- a/test/http/ajax.spec.js
+++ b/test/http/ajax.spec.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 import { expect } from 'chai';
 
-import ajax from '../../src/http/ajax';
+import { ajax } from '../../src/http/ajax';
 
 describe('http.ajax', function () {
   let fakeXhr;


### PR DESCRIPTION
Atualmente temos um problema para conseguir fazer mock de uma dependência importada dentro de um módulo, para podermos fazer teste unitário desse módulo. Com o sinon é fácil fazer mock quando o import da dependência na verdade é um objeto, mas quando o import é de uma função direto (que é o caso dos projetos que vão utilizar o commons), não é possível fazer o mock. 

No node-js isso se resolve com algumas bibliotecas que interceptam o require e forçam a passagem do mock pro módulo (acho meio gambiarrento mas funciona). Mas com o webpack a melhor alternativa que encontrei foi essa: https://stackoverflow.com/questions/35240469/how-to-mock-the-imports-of-an-es6-module (encontrei inclusive essa alternativa em diversos outros lugares, e parece ser a maneira mais utilizada mesmo).

O problema é que caso as funções sejam exportadas como `default` essa alternativa também não funciona. Ela só vai funcionar quando a dependência é exportada como uma _named dependency_ pois dessa forma o módulo precisa importa-la como um objeto dando um nome (é o fluxo padrão na definição de ES6 módules).

Então eu fiz a alteração para remover os `default exports` do projeto, possibilitando essa abordagem para criar mock das funções do commons nos testes unitários dos projetos que utilizarem.

