### PR TITLE
add params option to ajax function

### DIFF
--- a/test/http/ajax.spec.js
+++ b/test/http/ajax.spec.js
@@ -119,4 +119,83 @@ describe('http.ajax', function () {
       this.request.respond(200, {}, 'OK');
     },
   );
+
+  it('should pass params options on query', function (done) {
+    const baseUrl = 'http://www.google.com';
+    const fullUrl = 'http://www.google.com?q=query&user=user';
+
+    ajax({
+      url: baseUrl,
+      params: {
+        q: 'query',
+        user: 'user',
+      },
+      callback: () => {
+        expect(this.request.url).to.be.equal(fullUrl);
+        done();
+      },
+    });
+
+    this.request.respond(200, {}, 'OK');
+  });
+
+  it('should use "&" connector if url already have params', function (done) {
+    const baseUrl = 'http://www.google.com?test=2';
+    const fullUrl = 'http://www.google.com?test=2&q=query&user=user';
+
+    ajax({
+      url: baseUrl,
+      params: {
+        q: 'query',
+        user: 'user',
+      },
+      callback: () => {
+        expect(this.request.url).to.be.equal(fullUrl);
+        done();
+      },
+    });
+
+    this.request.respond(200, {}, 'OK');
+  });
+
+  it('should remove empty params', function (done) {
+    const baseUrl = 'http://www.google.com';
+    const fullUrl = 'http://www.google.com?q=query&user=user';
+
+    ajax({
+      url: baseUrl,
+      params: {
+        q: 'query',
+        user: 'user',
+        empty: undefined,
+        anotherEmpty: null,
+      },
+      callback: () => {
+        expect(this.request.url).to.be.equal(fullUrl);
+        done();
+      },
+    });
+
+    this.request.respond(200, {}, 'OK');
+  });
+
+  it('should serialize array params', function (done) {
+    const baseUrl = 'http://www.google.com';
+    const fullUrl =
+      'http://www.google.com?q[]=query&q[]=query2&q[]=query3&user=user';
+
+    ajax({
+      url: baseUrl,
+      params: {
+        q: ['query', 'query2', 'query3'],
+        user: 'user',
+      },
+      callback: () => {
+        expect(this.request.url).to.be.equal(fullUrl);
+        done();
+      },
+    });
+
+    this.request.respond(200, {}, 'OK');
+  });
 });


### PR DESCRIPTION
Adicionando a propriedade `params` para o método `ajax`.

O formato atual compartilhava o campo `data` tanto para envio de dados via POST, quanto para enviar os parâmetros da url. Acho isso meio ruim, em algumas situações nós precisamos enviar os dois, e nesse caso não daria pra diferenciar.

Esse formato de ter os dois parâmetros é o mesmo usado no axios: https://github.com/axios/axios#request-config.

Acho inclusive que depois a gente deveria tentar deixar essa nossa função de ajax bem parecida com a do axios, a gente tem usado nas nossas aplicações node, e funciona muito bem. Acha que faz sentido @andrewslince ?