### PR TITLE
feat: added stopPropagation, loadFile and objectMergeRecursive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -360,6 +360,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -371,6 +372,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -6501,7 +6503,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
     "./browser/isMobile": "./src/browser/isMobile",
     "./browser/getCookie": "./src/browser/getCookie",
     "./browser/setCookie": "./src/browser/setCookie",
-    "./browser/deleteCookie": "./src/browser/deleteCookie"
+    "./browser/deleteCookie": "./src/browser/deleteCookie",
+    "./browser/stopPropagation": "./src/browser/stopPropagation",
+    "./util": "./src/util",
+    "./util/loadFile": "./src/util/loadFile",
+    "./util/objectMergeRecursive": "./src/util/objectMergeRecursive"
   },
   "scripts": {
     "build": "gulp build",

--- a/src/browser/stopPropagation.js
+++ b/src/browser/stopPropagation.js
@@ -1,9 +1,17 @@
+/**
+ * Calls functions to prevent further propagation
+ * of a given event in the capturing and bubbling phases.
+ *
+ * @memberof module:@linx/commons-js/browser
+ * @method stopPropagation
+ * @param {object} event The event whose functions will be called
+ */
 export function stopPropagation(event) {
-  if (event.preventDefault) {
+  if (event.preventDefault && typeof event.preventDefault === 'function') {
     event.preventDefault();
   }
 
-  if (event.stopPropagation) {
+  if (event.stopPropagation && typeof event.stopPropagation === 'function') {
     event.stopPropagation();
   }
 

--- a/src/browser/stopPropagation.js
+++ b/src/browser/stopPropagation.js
@@ -1,0 +1,12 @@
+export function stopPropagation(event) {
+  if (event.preventDefault) {
+    event.preventDefault();
+  }
+
+  if (event.stopPropagation) {
+    event.stopPropagation();
+  }
+
+  // eslint-disable-next-line no-param-reassign
+  event.cancelBubble = true;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -14,10 +14,12 @@
 import browser from './browser';
 import http from './http';
 import queryString from './query-string';
+import util from './util';
+
 /**
  * @module @linx/commons-js
  */
-export const commons = { browser, http, queryString };
+export const commons = { browser, http, queryString, util };
 
 window.top.linx = window.top.linx || {};
 window.top.linx.commons = commons;

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -11,23 +11,12 @@
  * of the license agreement you entered into with Linx S.A.
  */
 
-import { getCookie } from './getCookie';
-import { isInViewport } from './isInViewport';
-import { isMobile } from './isMobile';
-import { setCookie } from './setCookie';
-import { deleteCookie } from './deleteCookie';
-import { stopPropagation } from './stopPropagation';
+import { loadFile } from './loadFile';
+import { objectMergeRecursive } from './objectMergeRecursive';
 
 /**
  * browser module.
  *
- * @module @linx/commons-js/browser
+ * @module @linx/commons-js/util
  */
-export {
-  isInViewport,
-  isMobile,
-  getCookie,
-  setCookie,
-  deleteCookie,
-  stopPropagation,
-};
+export { loadFile, objectMergeRecursive };

--- a/src/util/loadFile.js
+++ b/src/util/loadFile.js
@@ -1,4 +1,18 @@
-export function loadFile(source, callback) {
+/**
+ * Creates and appends an element that links the HTML document to a given file
+ * source and sets a callback function to be called once the element finishes
+ * loading.
+ *
+ * @memberof module:@linx/commons-js/util
+ * @method loadFile
+ * @param {string} source The path to the file that will be loaded.
+ * @param {function} callback The function to be called once the
+ * element created finishes loading.
+ * @param {object} document The document object to be used,
+ * defaults to Window.document.
+ * @returns {object} The element that was created and appended.
+ */
+export function loadFile(source, callback, document = window.document) {
   let file;
 
   if (source.includes('.js')) {
@@ -8,14 +22,15 @@ export function loadFile(source, callback) {
     file.setAttribute('src', source);
   } else if (source.includes('.css')) {
     file = document.createElement('link');
-    file.setAttribute('rel', 'stylesheet');
     file.setAttribute('type', 'text/css');
+    file.setAttribute('rel', 'stylesheet');
     file.setAttribute('href', source);
   }
 
   // Append in the HEAD element
   if (file) {
-    document.getElementsByTagName('head')[0].appendChild(file);
+    const [head] = document.getElementsByTagName('head');
+    head.appendChild(file);
 
     if (file.readyState) {
       file.onreadystatechange = () => {

--- a/src/util/loadFile.js
+++ b/src/util/loadFile.js
@@ -1,0 +1,42 @@
+export function loadFile(source, callback) {
+  let file;
+
+  if (source.includes('.js')) {
+    file = document.createElement('script');
+    file.setAttribute('type', 'text/javascript');
+    file.setAttribute('async', 'true');
+    file.setAttribute('src', source);
+  } else if (source.includes('.css')) {
+    file = document.createElement('link');
+    file.setAttribute('rel', 'stylesheet');
+    file.setAttribute('type', 'text/css');
+    file.setAttribute('href', source);
+  }
+
+  // Append in the HEAD element
+  if (file) {
+    document.getElementsByTagName('head')[0].appendChild(file);
+
+    if (file.readyState) {
+      file.onreadystatechange = () => {
+        if (file.readyState === 'loaded' || file.readyState === 'complete') {
+          file.onreadystatechange = null;
+
+          if (typeof callback === 'function') {
+            callback();
+          }
+        }
+      };
+    } else {
+      file.onload = () => {
+        file.onload = null;
+
+        if (typeof callback === 'function') {
+          callback();
+        }
+      };
+    }
+  }
+
+  return file;
+}

--- a/src/util/objectMergeRecursive.js
+++ b/src/util/objectMergeRecursive.js
@@ -1,0 +1,25 @@
+export function objectMergeRecursive(...args) {
+  const [target] = [args];
+
+  // eslint-disable-next-line no-plusplus
+  for (let i = 1; i < args.length; i++) {
+    const obj = args[i];
+
+    if (obj) {
+      // eslint-disable-next-line no-loop-func
+      Object.keys(obj).forEach((key) => {
+        if (
+          typeof key === 'object'
+          && !key.nodeType
+          && Object.prototype.toString(key) !== '[object Window]'
+        ) {
+          target[key] = objectMergeRecursive(target[key], obj[key]);
+        } else {
+          target[key] = obj[key];
+        }
+      });
+    }
+  }
+
+  return target;
+}

--- a/src/util/objectMergeRecursive.js
+++ b/src/util/objectMergeRecursive.js
@@ -1,21 +1,32 @@
+/**
+ * Merges two or more objects, combining common properties. Overwrites
+ * the properties from right to left in case of conflicts and concatenates
+ * properties that are all arrays.
+ *
+ * @memberof module:@linx/commons-js/util
+ * @method objectMergeRecursive
+ * @param {...object} source An object or array to be merged
+ * @returns {object} An object containing merged properties of all sources
+ * given.
+ */
 export function objectMergeRecursive(...args) {
-  const [target] = [args];
+  let target;
 
   // eslint-disable-next-line no-plusplus
-  for (let i = 1; i < args.length; i++) {
-    const obj = args[i];
+  for (let i = 0; i < args.length; i++) {
+    const source = args[i];
 
-    if (obj) {
+    if (Array.isArray(source)) {
+      target = (target || []).concat(source);
+    } else if (typeof source === 'object') {
+      if (Array.isArray(target) || target === undefined) {
+        target = {};
+      }
+
       // eslint-disable-next-line no-loop-func
-      Object.keys(obj).forEach((key) => {
-        if (
-          typeof key === 'object'
-          && !key.nodeType
-          && Object.prototype.toString(key) !== '[object Window]'
-        ) {
-          target[key] = objectMergeRecursive(target[key], obj[key]);
-        } else {
-          target[key] = obj[key];
+      Object.keys(source).forEach((key) => {
+        if (source[key] !== undefined) {
+          target[key] = source[key];
         }
       });
     }

--- a/test/browser/stopPropagation.spec.js
+++ b/test/browser/stopPropagation.spec.js
@@ -1,0 +1,24 @@
+import { expect, sinon } from '../globals';
+import { stopPropagation } from '../../src/browser/stopPropagation';
+
+describe('stopPropagation', function () {
+  it('should call preventDefault and stopPropagation if they exist', function () {
+    const mockEvent = {
+      preventDefault: sinon.stub(),
+      stopPropagation: sinon.stub(),
+    };
+
+    stopPropagation(mockEvent);
+
+    expect(mockEvent.preventDefault).to.be.called;
+    expect(mockEvent.stopPropagation).to.be.called;
+  });
+
+  it('should set a cancelBubble to true', function() {
+    const mockEvent = {};
+
+    stopPropagation(mockEvent);
+
+    expect(mockEvent.cancelBubble).to.equal(true);
+  });
+});

--- a/test/util/loadFile.spec.js
+++ b/test/util/loadFile.spec.js
@@ -1,0 +1,67 @@
+import { expect, sinon } from '../globals';
+import { loadFile } from '../../src/util/loadFile';
+
+describe('util/loadFile', function() {
+  const setAttributeStub = sinon.stub();
+  const appendChildStub = sinon.stub();
+  const callback = sinon.stub();
+  let mockDoc;
+
+  beforeEach(function() {
+    mockDoc = {
+      createElement: () => ({ setAttribute: setAttributeStub }),
+      getElementsByTagName: () => [{ appendChild: appendChildStub }],
+    };
+  });
+
+  afterEach(function() {
+    setAttributeStub.reset();
+    appendChildStub.reset();
+    callback.reset();
+  });
+
+  it('should set proper attributes when loading a javascript file', function() {
+    const mockSource = 'script.js';
+
+    const file = loadFile(mockSource, callback, mockDoc);
+
+    expect(setAttributeStub).to.be.calledWith('type', 'text/javascript');
+    expect(setAttributeStub).to.be.calledWith('async', 'true');
+    expect(setAttributeStub).to.be.calledWith('src', mockSource);
+    expect(appendChildStub).to.be.calledWith(file);
+  });
+
+  it('should set proper attributes when loading a css file', function() {
+    const mockSource = 'styles.css';
+
+    const file = loadFile(mockSource, callback, mockDoc);
+
+    expect(setAttributeStub).to.be.calledWith('type', 'text/css');
+    expect(setAttributeStub).to.be.calledWith('rel', 'stylesheet');
+    expect(setAttributeStub).to.be.calledWith('href', mockSource);
+    expect(appendChildStub).to.be.calledWith(file);
+  });
+
+  it('should set onreadystatechange to call the calledback passed', function() {
+    const mockSource = 'script.js';
+
+    mockDoc.createElement = () => ({
+      setAttribute: setAttributeStub,
+      readyState: 'loaded',
+    });
+
+    const file = loadFile(mockSource, callback, mockDoc);
+    file.onreadystatechange();
+
+    expect(callback).to.be.called;
+  });
+
+  it('should set onload to call the callback passed', function() {
+    const mockSource = 'script.js';
+
+    const file = loadFile(mockSource, callback, mockDoc);
+    file.onload();
+
+    expect(callback).to.be.called;
+  });
+});

--- a/test/util/objectMergeRecursive.spec.js
+++ b/test/util/objectMergeRecursive.spec.js
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+
+import { objectMergeRecursive } from '../../src/util/objectMergeRecursive';
+
+describe('objectMergeRecursive', function() {
+  it('should merge the objects', function() {
+    const mockObj1 = { a: 1, b: 2 };
+    const mockObj2 = { c: 5, d: 6 };
+    const expectedObj = { a: 1, b: 2, c: 5, d: 6 };
+    
+    expect(objectMergeRecursive(mockObj1, mockObj2)).to.deep.equal(expectedObj);
+  });
+
+  it('should overwrite the leftmost parameter if it conflicts with the next', function() {
+    const mockObj1 = { a: 1, b: 2 };
+    const mockObj2 = { b: 3, c: 4 };
+    const mockObj3 = { c: 5, d: 6 };
+    const expectedObj = { a: 1, b: 3, c: 5, d: 6 };
+
+    expect(objectMergeRecursive(mockObj1, mockObj2, mockObj3)).to.deep.equal(expectedObj);
+  });
+  
+  it('should not overwrite the leftmost parameter if the next is undefined', function() {
+    const mockObj1 = { a: 1, b: 2 };
+    const mockObj2 = { b: undefined, c: 4 };
+    const expectedObj = { a: 1, b: 2, c: 4 };
+
+    expect(objectMergeRecursive(mockObj1, mockObj2)).to.deep.equal(expectedObj);
+  });
+
+  it('should merge nested properties that are objects', function() {
+    const mockObj1 = { a: 1, b: { c: 2, d: 3 } };
+    const mockObj2 = { b: { c: 'some-string', d: { e: 0 } } };
+    const mockObj3 = { f: { g: 4 } };
+    const expectedObj = { a: 1, b: { c: 'some-string', d: { e: 0 } }, f: { g: 4 } };
+
+    expect(objectMergeRecursive(mockObj1, mockObj2, mockObj3)).to.deep.equal(expectedObj);
+  });
+
+  it('should concat parameters that are both arrays', function() {
+    const mockObj1 = [1,2,3];
+    const mockObj2 = [4,5,6];
+    const expectedObj = [1,2,3,4,5,6];
+
+    expect(objectMergeRecursive(mockObj1, mockObj2)).to.deep.equal(expectedObj);
+  });
+
+  it('should overwrite array parameter if the next is an object', function() {
+    const mockObj1 = [1];
+    const mockObj2 = { a: 0 };
+    const expectedObj = { a: 0 };
+
+    expect(objectMergeRecursive(mockObj1, mockObj2)).to.deep.equal(expectedObj);
+  });
+
+});


### PR DESCRIPTION
Nessa PR adicionamos:
* stopPropagation: chama o método `stopPropagation()` e equivalentes para um evento passado como parâmetro.
* loadFile: adiciona um determinado arquivo javascript ou css ao documento HTML.
* objectMergeRecursive: Combina recursivamente dois ou mais objetos e retorna o resultado como único objeto.