### PR TITLE
Breaking change: merge now mutates object

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
     {
       "name": "Andrew C. Pacifico",
       "email": "andrewpacifico@neemu.com"
+    },
+    {
+      "name": "Marx Guimaraes",
+      "email": "fidel.guimaraes@neemu.com"
     }
   ],
   "license": "MIT",

--- a/src/util/objectMergeRecursive.js
+++ b/src/util/objectMergeRecursive.js
@@ -10,22 +10,24 @@
  * given.
  */
 export function objectMergeRecursive(...args) {
-  let target;
+  let [target] = args;
 
   // eslint-disable-next-line no-plusplus
-  for (let i = 0; i < args.length; i++) {
+  for (let i = 1; i < args.length; i++) {
     const source = args[i];
 
     if (Array.isArray(source)) {
       target = (target || []).concat(source);
-    } else if (typeof source === 'object') {
+    } else {
       if (Array.isArray(target) || target === undefined) {
         target = {};
       }
 
       // eslint-disable-next-line no-loop-func
       Object.keys(source).forEach((key) => {
-        if (source[key] !== undefined) {
+        if (typeof target[key] === 'object' && typeof source[key] === 'object') {
+          target[key] = objectMergeRecursive(target[key], source[key]);
+        } else if (source[key] !== undefined) {
           target[key] = source[key];
         }
       });

--- a/test/util/objectMergeRecursive.spec.js
+++ b/test/util/objectMergeRecursive.spec.js
@@ -40,9 +40,14 @@ describe('objectMergeRecursive', function() {
   it('should concat parameters that are both arrays', function() {
     const mockObj1 = [1,2,3];
     const mockObj2 = [4,5,6];
-    const expectedObj = [1,2,3,4,5,6];
+    const expectedObj1 = [1,2,3,4,5,6];
 
-    expect(objectMergeRecursive(mockObj1, mockObj2)).to.deep.equal(expectedObj);
+    const mockObj3 = { a: [1, 2], b: 1 };
+    const mockObj4 = { a: [3, 4], b: 3 };
+    const expectedObj2 = { a: [1, 2, 3, 4], b: 3}
+
+    expect(objectMergeRecursive(mockObj1, mockObj2)).to.deep.equal(expectedObj1);
+    expect(objectMergeRecursive(mockObj3, mockObj4)).to.deep.equal(expectedObj2);
   });
 
   it('should overwrite array parameter if the next is an object', function() {
@@ -51,6 +56,28 @@ describe('objectMergeRecursive', function() {
     const expectedObj = { a: 0 };
 
     expect(objectMergeRecursive(mockObj1, mockObj2)).to.deep.equal(expectedObj);
+  });
+
+  it ('should mutate the first parameter with the result if that parameter is an object', function() {
+    const mockObj1 = { a: 1, b: 2 };
+    const mockObj2 = { c: 5, d: 6 };
+    const expectedObj = { a: 1, b: 2, c: 5, d: 6 };
+    
+    const result = objectMergeRecursive(mockObj1, mockObj2);
+
+    expect(result).to.equal(mockObj1);
+    expect(result).to.deep.equal(expectedObj);
+  });
+
+  it ('should not mutate the first parameter with the result if that parameter is an array', function() {
+    const mockObj1 = [1];
+    const mockObj2 = { a: 0 };
+    const expectedObj = { a: 0 };
+
+    const result = objectMergeRecursive(mockObj1, mockObj2);
+
+    expect(result).to.not.equal(mockObj1);
+    expect(result).to.deep.equal(expectedObj);
   });
 
 });


### PR DESCRIPTION
Precisamos que a função objectMergeRecursive do commons-js mutacione o primeiro objeto recebido em vez de retornar um novo objeto com o resultado da operação.