### PR TITLE
feat: formatCategories

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "./browser/deleteCookie": "./src/browser/deleteCookie",
     "./browser/stopPropagation": "./src/browser/stopPropagation",
     "./util": "./src/util",
+    "./util/formatCategories": "./src/util/formatCategories",
     "./util/formatCurrency": "./src/util/formatCurrency",
     "./util/loadFile": "./src/util/loadFile",
     "./util/objectMergeRecursive": "./src/util/objectMergeRecursive"

--- a/src/util/formatCategories.js
+++ b/src/util/formatCategories.js
@@ -1,0 +1,43 @@
+function getFirstChild(categories, item) {
+  return (categories || []).find(category => (
+    !category.used
+    && Array.isArray(category.parents)
+    && category.parents.indexOf(item.id) !== -1
+  ));
+}
+
+/**
+ * Formats an array of categories passed, sorting them
+ * based on hierarchic structure and returns an array
+ * of category ids.
+ *
+ * @memberof module:@linx-impulse/commons-js/util
+ * @method formatCategories
+ * @param {Array} An array of objects, each consisting of a category
+ * with id, name and an array of parents.
+ * @returns {Array} An array of strings where each string represents
+ * one category id.
+ */
+export function formatCategories(categories) {
+  // Filter wrong formatted
+  const filteredCategories = (categories || [])
+    .filter(category => category && category.id)
+    .map(category => ({ id: category.id, parents: category.parents }));
+
+  // Find the root node
+  let item = filteredCategories.find(category => (
+    (
+      !category.parents || (
+        Array.isArray(category.parents) && !category.parents.length
+      )
+    )
+  ));
+  const ids = [];
+
+  while (typeof item === 'object') {
+    ids.push(item.id);
+    item.used = true;
+    item = getFirstChild(filteredCategories, item);
+  }
+  return ids;
+}

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -13,6 +13,7 @@
 
 import { loadFile } from './loadFile';
 import { objectMergeRecursive } from './objectMergeRecursive';
+import { formatCategories } from './formatCategories';
 import { formatCurrency } from './formatCurrency';
 
 /**
@@ -20,4 +21,9 @@ import { formatCurrency } from './formatCurrency';
  *
  * @module @linx-impulse/commons-js/util
  */
-export { loadFile, objectMergeRecursive, formatCurrency };
+export {
+  loadFile,
+  objectMergeRecursive,
+  formatCategories,
+  formatCurrency
+};

--- a/test/util/formatCategories.spec.js
+++ b/test/util/formatCategories.spec.js
@@ -1,7 +1,7 @@
 import { expect, sinon } from '../globals';
 import { formatCategories } from '../../src/util/formatCategories';
 
-describe.only('util/formatCategories', function() {
+describe('util/formatCategories', function() {
   it('should return an array of category ids', function () {
     const mockCategories = [
       { id: 'cat-01', name: 'category-01' },

--- a/test/util/formatCategories.spec.js
+++ b/test/util/formatCategories.spec.js
@@ -2,7 +2,7 @@ import { expect, sinon } from '../globals';
 import { formatCategories } from '../../src/util/formatCategories';
 
 describe('util/formatCategories', function() {
-  it('should return an array of category ids', function () {
+  it('should return an array of category ids', function() {
     const mockCategories = [
       { id: 'cat-01', name: 'category-01' },
     ];
@@ -11,7 +11,7 @@ describe('util/formatCategories', function() {
     expect(result).to.deep.equal(['cat-01']);
   });
 
-  it('should sort categories with parents first', function () {
+  it('should sort categories with parents first', function() {
     const mockCategories = [
       { id: 'cat-01', name: 'category-01', parents: ['cat-02'] },
       { id: 'cat-02', name: 'category-02' }
@@ -21,15 +21,57 @@ describe('util/formatCategories', function() {
     expect(result).to.deep.equal(['cat-02', 'cat-01']);
   });
 
-  it('should remove categories outside of first parent tree', function() {
+  it('should remove children outside of first parent tree', function() {
     const mockCategories = [
       { id: 'cat-01', name: 'category-01', parents: ['cat-02'] },
       { id: 'cat-02', name: 'category-02' },
       { id: 'cat-03', name: 'category-03', parents: ['cat-02'] },
-      { id: 'cat-04', name: 'category-04' },
     ];
 
     const result = formatCategories(mockCategories);
     expect(result).to.deep.equal(['cat-02', 'cat-01']);
-  })
+  });
+
+  it('should remove parents outside of first parent tree', function() {
+    const mockCategories = [
+      { id: 'cat-01', name: 'category-01' },
+      { id: 'cat-02', name: 'category-02', parents: ['cat-01', 'cat-04'] },
+      { id: 'cat-03', name: 'category-03', parents: ['cat-02'] },
+      { id: 'cat-04', name: 'category-04' },
+      { id: 'cat-05', name: 'category-05', parents: ['cat-04'] },
+      { id: 'cat-06', name: 'category-06', parents: ['cat-05'] },
+    ];
+
+    const result = formatCategories(mockCategories);
+    expect(result).to.deep.equal(['cat-01', 'cat-02', 'cat-03']);
+  });
+
+  it('should remove unrelated categories outside of first parent tree', function() {
+    const mockCategories = [
+      { id: 'cat-01', name: 'category-01' },
+      { id: 'cat-02', name: 'category-02', parents: ['cat-01'] },
+      { id: 'cat-03', name: 'category-03' },
+      { id: 'cat-04', name: 'category-04' },
+      { id: 'cat-05', name: 'category-05' },
+      { id: 'cat-06', name: 'category-06' },
+    ];
+
+    const result = formatCategories(mockCategories);
+    expect(result).to.deep.equal(['cat-01', 'cat-02']);
+  });
+
+  it('should remove all cycles found in the parent tree', function() {
+    const mockCategories = [
+      { id: 'cat-01', name: 'category-01', parents: ['cat-01'] },
+      { id: 'cat-02', name: 'category-02', parents: ['cat-03'] },
+      { id: 'cat-03', name: 'category-03', parents: ['cat-02'] },
+      { id: 'cat-04', name: 'category-04', parents: ['cat-05'] },
+      { id: 'cat-05', name: 'category-05', parents: ['cat-06'] },
+      { id: 'cat-06', name: 'category-06', parents: ['cat-04'] },
+      { id: 'cat-07', name: 'category-07' },
+    ];
+
+    const result = formatCategories(mockCategories);
+    expect(result).to.deep.equal(['cat-07']);
+  });
 });

--- a/test/util/formatCategories.spec.js
+++ b/test/util/formatCategories.spec.js
@@ -1,0 +1,35 @@
+import { expect, sinon } from '../globals';
+import { formatCategories } from '../../src/util/formatCategories';
+
+describe.only('util/formatCategories', function() {
+  it('should return an array of category ids', function () {
+    const mockCategories = [
+      { id: 'cat-01', name: 'category-01' },
+    ];
+
+    const result = formatCategories(mockCategories);
+    expect(result).to.deep.equal(['cat-01']);
+  });
+
+  it('should sort categories with parents first', function () {
+    const mockCategories = [
+      { id: 'cat-01', name: 'category-01', parents: ['cat-02'] },
+      { id: 'cat-02', name: 'category-02' }
+    ];
+
+    const result = formatCategories(mockCategories);
+    expect(result).to.deep.equal(['cat-02', 'cat-01']);
+  });
+
+  it('should remove categories outside of first parent tree', function() {
+    const mockCategories = [
+      { id: 'cat-01', name: 'category-01', parents: ['cat-02'] },
+      { id: 'cat-02', name: 'category-02' },
+      { id: 'cat-03', name: 'category-03', parents: ['cat-02'] },
+      { id: 'cat-04', name: 'category-04' },
+    ];
+
+    const result = formatCategories(mockCategories);
+    expect(result).to.deep.equal(['cat-02', 'cat-01']);
+  })
+});


### PR DESCRIPTION
Adicionando o famoso flattenCategories ao commons-js uma vez que já utilizado em vários lugares e agora será adicionado ao novo engage-onsite-js.

Sugestões de mais testes para adicionar são bem-vindas.