### PR TITLE
feat: promisify ajax response

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,46 @@
+<!---
+  > INSTRUÇÕES GERAIS PARA ABRIR ESSE PULL REQUEST
+  Olá! É bem importante que você preencha a descrição desse PR com as
+  informações sugeridas abaixo, para ajudar a dar o máximo possível de
+  contexto/objetivo/motivação e instruções de teste das alterações.
+  Por favor, depois de preencher os campos, não esqueça de:
+  1) Dar assign no PR para você
+  2) Remover todos os comentários que não se aplicam nessa alteração
+  Obrigado! :)
+  -----
+  ENGAGE RECS TEAM
+-->
+
+### Problema/Motivação
+<!--
+  Descreva o problema/motivação que gerou a necessidade das alterações desse PR.
+-->
+
+<INSIRA UMA DESCRIÇÃO AQUI>
+
+### O que foi feito
+<!--
+  Escreva de forma descritiva ou através de uma lista os pontos que foram
+  implementados ou ajustados nesse PR.
+ -->
+
+* Item 1
+* Item 2
+
+### Como testar
+<!--
+  É bem importante que você escreva instruções claras de:
+  1) como as alterações podem ser testadas localmente
+  2) quais os resultados esperados
+-->
+
+* Instrução de teste 1
+* Instrução de teste 2
+
+### Links úteis
+<!--
+  Adicione aqui todos os links que você julgar necessários para ajudar a
+  contextualizar a revisão das alterações.
+-->
+
+* **Task no Asana:** [TÍTULO_DA_TASK](URL_DA_TASK)

--- a/test/http/ajax.spec.js
+++ b/test/http/ajax.spec.js
@@ -4,16 +4,20 @@ import { ajax } from '../../src/http/ajax';
 
 describe('http.ajax', function () {
   let fakeXhr;
+  let sandbox;
 
   beforeEach(function () {
     fakeXhr = sinon.useFakeXMLHttpRequest();
     fakeXhr.onCreate = (xhr) => {
       this.request = xhr;
     };
+
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(function () {
     fakeXhr.restore();
+    sandbox.restore();
   });
 
   it('should return a promise that resolves when successful', function () {
@@ -26,26 +30,30 @@ describe('http.ajax', function () {
     expect(response).to.eventually.equal(expectedResponse);
   });
 
-  it('should run the callback option on successful responses', function (done) {
+  it('should run the callback option on successful responses', function () {
+    const callbackStub = sandbox.stub();
+
     ajax({
       url: 'http://www.google.com',
-      callback: () => {
-        done();
-      },
+      callback: callbackStub,
     });
 
     this.request.respond(200, {}, 'OK');
+
+    expect(callbackStub).to.have.been.calledOnce;
   });
 
-  it('should run the callback option on error responses', function (done) {
+  it('should run the callback option on error responses', function () {
+    const callbackStub = sandbox.stub();
+
     ajax({
       url: 'http://www.google.com',
-      callback: () => {
-        done();
-      },
+      callback: callbackStub,
     });
 
     this.request.error();
+
+    expect(callbackStub).to.have.been.calledOnce;
   });
 
   it('should run the callback option when request times out', function () {
@@ -63,57 +71,62 @@ describe('http.ajax', function () {
     expect(callbackStub).to.have.been.calledOnce;
   });
 
-  it('should run the success option on successful responses', function (done) {
+  it('should run the success option on successful responses', function () {
+    const successStub = sinon.stub();
+
     ajax({
       url: 'http://www.google.com',
-      success: () => {
-        done();
-      },
+      success: successStub,
     });
 
     this.request.respond(200, {}, 'OK');
+
+    expect(successStub).to.have.been.calledOnce;
   });
 
-  it('should pass response data to success callback', function (done) {
+  it('should pass response data to success callback', function () {
+    const successStub = sinon.stub();
+
     const responseData = 'ok';
 
     ajax({
       url: 'http://www.google.com',
-      success: (data) => {
-        expect(data).to.be.equal(responseData);
-        done();
-      },
+      success: successStub,
     });
 
     this.request.respond(200, {}, responseData);
+
+    expect(successStub).to.have.been.calledOnce;
+    expect(successStub).to.have.been.calledWith(responseData);
   });
 
-  it('should parse response data if its a json', function (done) {
+  it('should parse response data if its a json', function () {
+    const successStub = sinon.stub();
+
     const responseData = { data: 'ok' };
 
     ajax({
       url: 'http://www.google.com',
-      success: (data) => {
-        expect(data).to.deep.equal(responseData);
-        done();
-      },
+      success: successStub,
     });
 
     this.request.respond(200, {}, JSON.stringify(responseData));
+
+    expect(successStub).to.have.been.calledOnce;
+    expect(successStub).to.have.been.calledWith(responseData);
   });
 
-  it('should not run the success option on error responses', function (done) {
+  it('should not run the success option on error responses', function () {
+    const successStub = sinon.stub();
+
     ajax({
       url: 'http://www.google.com',
-      success: () => {
-        done.fail();
-      },
-      error: () => {
-        done();
-      },
+      success: successStub,
     });
 
     this.request.error();
+
+    expect(successStub).to.not.have.been.called;
   });
 
   it('should return a promise that rejects when request times out', function () {
@@ -152,15 +165,17 @@ describe('http.ajax', function () {
     expect(response).to.be.rejected;
   });
 
-  it('should run the error option on error responses', function (done) {
+  it('should run the error option on error responses', function () {
+    const errorStub = sandbox.stub();
+
     ajax({
       url: 'http://www.google.com',
-      error: () => {
-        done();
-      },
+      error: errorStub,
     });
 
     this.request.error();
+
+    expect(errorStub).to.have.been.calledOnce;
   });
 
   it('should return a promise that rejects if response status is higher than 300', function () {
@@ -201,22 +216,18 @@ describe('http.ajax', function () {
     expect(errorStub).to.have.been.calledOnce;
   });
 
-  it(
-    'should not run the error option on successful responses',
-    function (done) {
-      ajax({
-        url: 'http://www.google.com',
-        success: () => {
-          done();
-        },
-        error: () => {
-          done.fail();
-        },
-      });
+  it('should not run the error option on successful responses', function () {
+    const errorStub = sandbox.stub();
 
-      this.request.respond(200, {}, 'OK');
-    },
-  );
+    ajax({
+      url: 'http://www.google.com',
+      error: errorStub,
+    });
+
+    this.request.respond(200, {}, 'OK');
+
+    expect(errorStub).to.not.have.been.called;
+  });
 
   it('should pass params options on query', function (done) {
     const baseUrl = 'http://www.google.com';


### PR DESCRIPTION
### Problema/Motivação
Com o advento da nova versão do SDK do onsite, precisamos atualizar o ajax, pois atualmente ele funciona apenas com callbacks, o que limita a maneira como podemos codificar o sdk.

### O que foi feito
* Foi modificada a função `ajax` para, além de chamar os callbacks passados, também retornar uma promisse que resolve ou rejeita quando a requisição é concluída.
* Foram adicionamos testes para esse novo comportamento e também refatorados alguns testes antigos.

### Como testar
TODO