### PR TITLE
Feat/accept string categories

### DIFF
--- a/src/util/formatCategories.js
+++ b/src/util/formatCategories.js
@@ -19,25 +19,41 @@ function getFirstChild(categories, item) {
  * one category id.
  */
 export function formatCategories(categories) {
+  // check if categories is an array of strings
+  if (categories.every(category => typeof category === 'string')) {
+    return [categories.join('_')];
+  }
+
   // Filter wrong formatted
   const filteredCategories = (categories || [])
     .filter(category => category && category.id)
-    .map(category => ({ id: category.id, parents: category.parents }));
+    .map(category => ({
+      id: category.id,
+      parents: category.parents,
+    }));
 
-  // Find the root node
-  let item = filteredCategories.find(category => (
+  // Filter the root nodes
+  const roots = filteredCategories.filter(category => (
     (
       !category.parents || (
         Array.isArray(category.parents) && !category.parents.length
       )
     )
   ));
-  const ids = [];
 
-  while (typeof item === 'object') {
-    ids.push(item.id);
-    item.used = true;
-    item = getFirstChild(filteredCategories, item);
-  }
-  return ids;
+  // For each root generate an array of categories
+  const result = roots.map((root) => {
+    let item = root;
+    const ids = [];
+
+    while (typeof item === 'object') {
+      ids.push(item.id);
+      item.used = true;
+      item = getFirstChild(categories, item);
+    }
+
+    return ids.join('_');
+  });
+
+  return result;
 }

--- a/src/util/formatCategories.js
+++ b/src/util/formatCategories.js
@@ -1,9 +1,20 @@
-function getFirstChild(categories, item) {
-  return (categories || []).find(category => (
-    !category.used
-    && Array.isArray(category.parents)
+function getChildren(categories, item) {
+  return (categories || []).filter(category => (
+    Array.isArray(category.parents)
     && category.parents.indexOf(item.id) !== -1
   ));
+}
+
+function flatten(categories, root, result, acc = '') {
+  const children = getChildren(categories, root);
+
+  if (!children.length) {
+    result.push(acc);
+  }
+
+  children.forEach((child) => {
+    flatten(categories, child, result, `${acc}_${child.id}`);
+  });
 }
 
 /**
@@ -42,17 +53,9 @@ export function formatCategories(categories) {
   ));
 
   // For each root generate an array of categories
-  const result = roots.map((root) => {
-    let item = root;
-    const ids = [];
-
-    while (typeof item === 'object') {
-      ids.push(item.id);
-      item.used = true;
-      item = getFirstChild(categories, item);
-    }
-
-    return ids.join('_');
+  const result = [];
+  roots.forEach((root) => {
+    flatten(categories, root, result, root.id);
   });
 
   return result;

--- a/test/util/formatCategories.spec.js
+++ b/test/util/formatCategories.spec.js
@@ -36,7 +36,7 @@ describe('util/formatCategories', function() {
     ];
 
     const result = formatCategories(mockCategories);
-    expect(result).to.deep.equal(['cat-02_cat-01']);
+    expect(result).to.deep.equal(['cat-02_cat-01', 'cat-02_cat-03']);
   });
 
   it('should one string for each parent tree', function() {
@@ -50,7 +50,7 @@ describe('util/formatCategories', function() {
     ];
 
     const result = formatCategories(mockCategories);
-    expect(result).to.deep.equal(['cat-01_cat-02_cat-03', 'cat-04_cat-05_cat-06']);
+    expect(result).to.deep.equal(['cat-01_cat-02_cat-03', 'cat-04_cat-02_cat-03', 'cat-04_cat-05_cat-06']);
   });
 
   it('should return one string for each category without parents', function() {

--- a/test/util/formatCategories.spec.js
+++ b/test/util/formatCategories.spec.js
@@ -2,13 +2,20 @@ import { expect, sinon } from '../globals';
 import { formatCategories } from '../../src/util/formatCategories';
 
 describe('util/formatCategories', function() {
-  it('should return an array of category ids', function() {
+  it('should return an array of category trees', function() {
     const mockCategories = [
       { id: 'cat-01', name: 'category-01' },
     ];
 
     const result = formatCategories(mockCategories);
     expect(result).to.deep.equal(['cat-01']);
+  });
+
+  it('should return an array with a single string when categories is an array of strings', function () {
+    const mockCategories = ['category-01', 'category-02', 'category-03'];
+
+    const result = formatCategories(mockCategories);
+    expect(result).to.deep.equal(['category-01_category-02_category-03']);
   });
 
   it('should sort categories with parents first', function() {
@@ -18,7 +25,7 @@ describe('util/formatCategories', function() {
     ];
 
     const result = formatCategories(mockCategories);
-    expect(result).to.deep.equal(['cat-02', 'cat-01']);
+    expect(result).to.deep.equal(['cat-02_cat-01']);
   });
 
   it('should remove children outside of first parent tree', function() {
@@ -29,10 +36,10 @@ describe('util/formatCategories', function() {
     ];
 
     const result = formatCategories(mockCategories);
-    expect(result).to.deep.equal(['cat-02', 'cat-01']);
+    expect(result).to.deep.equal(['cat-02_cat-01']);
   });
 
-  it('should remove parents outside of first parent tree', function() {
+  it('should one string for each parent tree', function() {
     const mockCategories = [
       { id: 'cat-01', name: 'category-01' },
       { id: 'cat-02', name: 'category-02', parents: ['cat-01', 'cat-04'] },
@@ -43,10 +50,10 @@ describe('util/formatCategories', function() {
     ];
 
     const result = formatCategories(mockCategories);
-    expect(result).to.deep.equal(['cat-01', 'cat-02', 'cat-03']);
+    expect(result).to.deep.equal(['cat-01_cat-02_cat-03', 'cat-04_cat-05_cat-06']);
   });
 
-  it('should remove unrelated categories outside of first parent tree', function() {
+  it('should return one string for each category without parents', function() {
     const mockCategories = [
       { id: 'cat-01', name: 'category-01' },
       { id: 'cat-02', name: 'category-02', parents: ['cat-01'] },
@@ -57,7 +64,7 @@ describe('util/formatCategories', function() {
     ];
 
     const result = formatCategories(mockCategories);
-    expect(result).to.deep.equal(['cat-01', 'cat-02']);
+    expect(result).to.deep.equal(['cat-01_cat-02', 'cat-03', 'cat-04', 'cat-05', 'cat-06']);
   });
 
   it('should remove all cycles found in the parent tree', function() {


### PR DESCRIPTION
### Problema/Motivação
O onsite autoservido não suporta o formato de categoria simplificado (Array de strings).

### O que foi feito
Modificamos o formatCategories para suportar um array de objetos ou de strings e retornar um array de strings onde cada string representa uma árvore de categoria (formato da api v1 do onsite).

### Como testar
Existem duas maneiras de testar:

* Importar o arquivo src/util/formatCategories em um console do node e usar a função (é preciso trocar exports por module.exports =...)
* Usar o yalc para linkar este branch do commons-js no engage-onsite-js.

Como usar o yalc:
1. Instalar o yalc globalmente com `npm i -g yalc`.
2. Clonar este repositório e rodar `npm run build`.
3. Publicar o commons no repositório local do yalc com `yalc publish`.
4. No repositório do engage-onsite-js executar o comando `docker-compose run app yalc add @linx-impulse/commons-js`.
5. Executar `make build` para deployar o engage-onsite-js localmente.

### Links úteis
<!--
  Adicione aqui todos os links que você julgar necessários para ajudar a
  contextualizar a revisão das alterações.
-->

* **Task no Asana:** [[kutiz] [onsite] Produtos de subsubcategoria não estão sendo exibidos em vitrine mais populares](https://app.asana.com/0/73480197165619/1199084251551953/f)
